### PR TITLE
Specify `--openssldir` when `fips_mode=true`

### DIFF
--- a/config/software/openssl.rb
+++ b/config/software/openssl.rb
@@ -85,7 +85,9 @@ build do
     "shared",
   ]
 
-  configure_args += ["--with-fipsdir=#{install_dir}/embedded", "fips"] if fips_mode?
+  # For OpenSSL <= 1.0.2, `--prefix` and `--openssldir` should be specified.
+  # See https://wiki.openssl.org/index.php/Compilation_and_Installation#PREFIX_and_OPENSSLDIR
+  configure_args += ["--with-fipsdir=#{install_dir}/embedded", "fips", "--openssldir=#{install_dir}/embedded"] if fips_mode?
 
   configure_cmd =
     if aix?


### PR DESCRIPTION
If `fips_mode=true`, when specifying `--prefix` during the `./configuration` process, it's documented to also specify `--openssldir` to keep sane functionality.  See: https://wiki.openssl.org/index.php/Compilation_and_Installation#PREFIX_and_OPENSSLDIR.

> It is usually not necessary to specify --prefix. If --prefix is not specified, then --openssldir is used. However, specifying only --prefix may result in broken builds because the 1.0.2 build system attempts to build in a FIPS configuration.
